### PR TITLE
Use api subdomain to avoid issues with incapsula

### DIFF
--- a/lib/challonge/match.rb
+++ b/lib/challonge/match.rb
@@ -1,7 +1,7 @@
 # the only attributes that will save are: scores_csv, winner_id
 
 class Challonge::Match < Challonge::API
-  self.site = "https://challonge.com/api/tournaments/:tournament_id"
+  self.site = "https://api.challonge.com/api/tournaments/:tournament_id"
 
   def tournament
     Challonge::Tournament.find(self.prefix_options[:tournament_id])
@@ -10,15 +10,15 @@ class Challonge::Match < Challonge::API
   def tournament=(tournament)
     self.prefix_options[:tournament_id] = tournament.id
   end
-  
+
   def player1
     _find_player(:player1_id)
   end
-  
+
   def player2
     _find_player(:player2_id)
   end
-  
+
   def player_winner? (participant)
     (participant.id != self.winner_id)
   end
@@ -34,7 +34,7 @@ class Challonge::Match < Challonge::API
   def readonly_attributes
     %w/prerequisite_match_ids_csv/
   end
-  
+
   private
   def _find_player(player)
     if self.attributes[player] != nil

--- a/lib/challonge/participant.rb
+++ b/lib/challonge/participant.rb
@@ -1,7 +1,7 @@
 # the only attributes that will save are: name, seed, challonge_username, email, misc
 
 class Challonge::Participant < Challonge::API
-  self.site = "https://challonge.com/api/tournaments/:tournament_id"
+  self.site = "https://api.challonge.com/api/tournaments/:tournament_id"
 
   def initialize(attributes = {}, persisted = false)
     @attributes     = {}
@@ -27,7 +27,7 @@ class Challonge::Participant < Challonge::API
   def randomize!
     validated_post(:randomize)
   end
-  
+
   def name
     super ? super : @attributes["challonge_username"]
   end

--- a/lib/challonge/tournament.rb
+++ b/lib/challonge/tournament.rb
@@ -1,5 +1,5 @@
 class Challonge::Tournament < Challonge::API
-  self.site = "https://challonge.com/api"
+  self.site = "https://api.challonge.com/api"
 
   def description
     if self.attributes.include?('description_source')


### PR DESCRIPTION
It turns out the lack of 'api' subdomain was causing requests to be blocked by Incapsula.
